### PR TITLE
Pull Request for #63: Make current dependencies optional

### DIFF
--- a/analysis/SConstruct
+++ b/analysis/SConstruct
@@ -8,6 +8,7 @@ from configuration_test import configuration_test
 [mode, stata_executable, cache_dir] = configuration_test(ARGUMENTS, gslab_python_version = '4.1.0')
 import gslab_scons as gs
 import gslab_scons.log as log
+from gslab_scons import configuration_tests as config
 import yaml
 import atexit
 
@@ -19,14 +20,19 @@ log.start_log(mode, vers)
 # Define the SCons environment
 env = Environment(ENV = {'PATH': os.environ['PATH']}, 
                   IMPLICIT_COMMAND_DEPENDENCIES = 0,
-                  BUILDERS = {'BuildLatex':  Builder(action = gs.build_latex),
-                              'BuildLyx':    Builder(action = gs.build_lyx),
-                              'BuildMatlab': Builder(action = gs.build_matlab),
+                  BUILDERS = {
+                              # 'BuildLatex' : Builder(action = gs.build_latex),
+                              'BuildLyx'   : Builder(action = gs.build_lyx),
+                              # 'BuildMatlab': Builder(action = gs.build_matlab),
                               'BuildPython': Builder(action = gs.build_python),
-                              'BuildR':      Builder(action = gs.build_r),
-                              'BuildStata':  Builder(action = gs.build_stata),
-                              'Tablefill':   Builder(action = gs.build_tables)},
+                              # 'BuildR'     : Builder(action = gs.build_r),
+                              # 'BuildStata' : Builder(action = gs.build_stata),
+                              'Tablefill'  : Builder(action = gs.build_tables)
+                              },
                   stata_executable = stata_executable)
+
+# Check requirements for all builders
+config.check_builders(env)
 
 # Only computes hash if time-stamp changed
 env.Decider('MD5-timestamp') 

--- a/analysis/SConstruct
+++ b/analysis/SConstruct
@@ -1,20 +1,18 @@
 # Preliminaries
 import os
 import sys
+import atexit
+import yaml
+sys.path.append('../config')
 sys.dont_write_bytecode = True # Don't write .pyc files
 
-# Test for proper prerequisites and setup
-from configuration_test import configuration_test
-[mode, stata_executable, cache_dir] = configuration_test(ARGUMENTS, gslab_python_version = '4.1.0')
+# Setup
+from configuration import configuration
+[mode, vers, cache_dir] = configuration(ARGUMENTS)
 import gslab_scons as gs
-import gslab_scons.log as log
-from gslab_scons import configuration_tests as config
-import yaml
-import atexit
+from gslab_scons import log, misc
 
-# Start log after getting mode and release version
-mode = ARGUMENTS.get('mode', 'develop') 
-vers = ARGUMENTS.get('version', '') 
+# Start log
 log.start_log(mode, vers)
 
 # Define the SCons environment
@@ -28,11 +26,8 @@ env = Environment(ENV = {'PATH': os.environ['PATH']},
                               # 'BuildR'     : Builder(action = gs.build_r),
                               # 'BuildStata' : Builder(action = gs.build_stata),
                               'Tablefill'  : Builder(action = gs.build_tables)
-                              },
-                  stata_executable = stata_executable)
+                              })
 
-# Check requirements for all builders
-config.check_builders(env)
 
 # Only computes hash if time-stamp changed
 env.Decider('MD5-timestamp') 
@@ -41,6 +36,9 @@ env.EXTENSIONS = ['.eps', '.pdf', '.lyx']
 SourceFileScanner.add_scanner('.lyx', Scanner(gs.misc.lyx_scan, recursive = True))
 # Load paths
 env['PATHS'] = yaml.load(open('config_global.yaml', 'rU'))
+# Load Stata executable if Stata builder is defined
+if 'BuildStata' in env['BUILDERS'].keys():
+   env['stata_executable'] = misc.load_yaml_value('config_user.yaml', 'stata_executable')
 
 # Export environment
 Export('env')

--- a/analysis/SConstruct
+++ b/analysis/SConstruct
@@ -19,13 +19,10 @@ log.start_log(mode, vers)
 env = Environment(ENV = {'PATH': os.environ['PATH']}, 
                   IMPLICIT_COMMAND_DEPENDENCIES = 0,
                   BUILDERS = {
-                              # 'BuildLatex' : Builder(action = gs.build_latex),
-                              'BuildLyx'   : Builder(action = gs.build_lyx),
                               # 'BuildMatlab': Builder(action = gs.build_matlab),
                               'BuildPython': Builder(action = gs.build_python),
                               # 'BuildR'     : Builder(action = gs.build_r),
                               # 'BuildStata' : Builder(action = gs.build_stata),
-                              'Tablefill'  : Builder(action = gs.build_tables)
                               })
 
 

--- a/analysis/config_global.yaml
+++ b/analysis/config_global.yaml
@@ -7,3 +7,6 @@ build:
 source:
   prepare_data: source/prepare_data
   descriptive: source/descriptive
+
+# Switch to 'Yes' if it's required and 'No' if it's not.
+prereq_git-lfs: Yes

--- a/analysis/config_global.yaml
+++ b/analysis/config_global.yaml
@@ -8,10 +8,6 @@ source:
   prepare_data: source/prepare_data
   descriptive: source/descriptive
 
-# Switch to 'Yes' if any of the following softwares are required
-prereq_git-lfs: Yes
-prereq_Latex: No
-prereq_Lyx: No
-prereq_Matlab: No
-prereq_R: No
-prereq_Stata: No
+Stata: yaml, preliminaries, matrix_to_txt
+R: yaml
+Matlab: yaml

--- a/analysis/config_global.yaml
+++ b/analysis/config_global.yaml
@@ -7,7 +7,3 @@ build:
 source:
   prepare_data: source/prepare_data
   descriptive: source/descriptive
-
-Stata: yaml, preliminaries, matrix_to_txt
-R: yaml
-Matlab: yaml

--- a/analysis/configuration_test.py
+++ b/analysis/configuration_test.py
@@ -26,18 +26,7 @@ def configuration_test(ARGUMENTS, gslab_python_version):
     config.check_python(gslab_python_version = gslab_python_version, 
                         packages = ['yaml', 'gslab_scons', 'gslab_fill'])
 
-    # Read YAML file and check if the softwares are required.
-    prereq_checks = {'git-lfs': config.check_lfs,
-                     'Latex'  : (lambda *args: None),
-                     'Lyx'    : config.check_lyx,
-                     'Matlab' : (lambda *args: None),
-                     'R'      : config.check_r,
-                     'Stata'  : config.check_stata}
-    for prereq in prereq_checks.keys():
-        require = misc.load_yaml_value('config_global.yaml', 'prereq_%s' % prereq)
-        if require:
-            prereq_checks[prereq]()
-
+    config.check_lfs()
     # Loads arguments and configurations
     mode = ARGUMENTS.get('mode', 'develop') # Gets mode; defaults to 'develop'
 

--- a/analysis/release/descriptive/plot.eps
+++ b/analysis/release/descriptive/plot.eps
@@ -1,7 +1,7 @@
 %!PS-Adobe-3.0 EPSF-3.0
 %%Title: build/descriptive/plot.eps
 %%Creator: matplotlib version 1.5.1, http://matplotlib.org/
-%%CreationDate: Mon Aug 28 09:22:02 2017
+%%CreationDate: Wed Aug 30 16:06:06 2017
 %%Orientation: portrait
 %%BoundingBox: 18 180 594 612
 %%EndComments

--- a/analysis/release/descriptive/sconscript_descriptive.log
+++ b/analysis/release/descriptive/sconscript_descriptive.log
@@ -1,3 +1,3 @@
-*** Builder log created: {2017-08-28 09:21:59} 
-*** Builder log completed: {2017-08-28 09:22:02} 
+*** Builder log created: {2017-08-30 16:06:05} 
+*** Builder log completed: {2017-08-30 16:06:06} 
  

--- a/analysis/release/sconstruct.log
+++ b/analysis/release/sconstruct.log
@@ -1,9 +1,9 @@
-*** New build: {2017-08-28 09:22:05} ***
+*** New build: {2017-08-29 16:04:05} ***
 scons: done reading SConscript files.
 scons: Building targets ...
 scons: `build' is up to date.
 scons: `release' is up to date.
 scons: done building targets.
-*** Build completed: {2017-08-28 09:22:05} ***
+*** Build completed: {2017-08-29 16:04:06} ***
  
  

--- a/analysis/release/sconstruct.log
+++ b/analysis/release/sconstruct.log
@@ -1,9 +1,9 @@
-*** New build: {2017-08-29 16:04:05} ***
+*** New build: {2017-08-30 16:06:12} ***
 scons: done reading SConscript files.
 scons: Building targets ...
 scons: `build' is up to date.
 scons: `release' is up to date.
 scons: done building targets.
-*** Build completed: {2017-08-29 16:04:06} ***
+*** Build completed: {2017-08-30 16:06:12} ***
  
  

--- a/analysis/release/sconstruct.log
+++ b/analysis/release/sconstruct.log
@@ -1,9 +1,9 @@
-*** New build: {2017-08-30 16:06:12} ***
+*** New build: {2017-08-31 09:01:34} ***
 scons: done reading SConscript files.
 scons: Building targets ...
 scons: `build' is up to date.
 scons: `release' is up to date.
 scons: done building targets.
-*** Build completed: {2017-08-30 16:06:12} ***
+*** Build completed: {2017-08-31 09:01:34} ***
  
  

--- a/analysis/release/state_of_repo.log
+++ b/analysis/release/state_of_repo.log
@@ -8,19 +8,26 @@ as it can be edited after state_of_repo.log finishes running
 ===================================
 Last commit:
 
-commit 465b8d9f106e4753bbe020d28d944c38128b1324
+commit 5d85886f5a4b83fbe91cb9988373921cdbbba603
 Author: chuanyu <yuchuan2016@gmail.com>
-Date:   Tue Aug 29 16:12:39 2017 -0700
+Date:   Wed Aug 30 16:07:40 2017 -0700
 
-    #63 add builder check
+    #63 add autimatic config scripts
 
 
 Files changed since last commit:
 
-analysis/release/descriptive/plot.eps
-analysis/release/descriptive/sconscript_descriptive.log
+analysis/SConstruct
+analysis/config_global.yaml
 analysis/release/sconstruct.log
 analysis/release/state_of_repo.log
+config/config_python.py
+config/config_r.r
+config/configuration.py
+paper_slides/SConstruct
+paper_slides/config_global.yaml
+paper_slides/release/sconstruct.log
+paper_slides/release/state_of_repo.log
 
 ===================================
 
@@ -28,49 +35,49 @@ analysis/release/state_of_repo.log
 
 ===================================
 ./config_global.yaml:
-   modified on: 30 Aug 2017 13:28:40
-   size of file: 195
+   modified on: 31 Aug 2017 08:51:04
+   size of file: 273
 ./config_user.yaml:
    modified on: 25 Aug 2017 11:06:38
    size of file: 70
 ./SConstruct:
-   modified on: 30 Aug 2017 16:02:14
-   size of file: 2250
+   modified on: 31 Aug 2017 08:50:15
+   size of file: 2013
 ./sconstruct.log:
-   modified on: 30 Aug 2017 16:06:12
+   modified on: 31 Aug 2017 09:01:34
    size of file: 199
 ./state_of_repo.log:
-   modified on: 30 Aug 2017 16:06:12
-   size of file: 576
+   modified on: 31 Aug 2017 09:01:34
+   size of file: 738
 ./build/descriptive/plot.eps:
-   modified on: 30 Aug 2017 16:06:06
+   modified on: 30 Aug 2017 16:56:33
    size of file: 15385
 ./build/descriptive/sconscript_descriptive.log:
-   modified on: 30 Aug 2017 16:06:06
+   modified on: 30 Aug 2017 16:56:33
    size of file: 99
 ./build/descriptive/table.txt:
-   modified on: 30 Aug 2017 16:06:06
+   modified on: 30 Aug 2017 16:56:33
    size of file: 39
 ./build/prepare_data/data.txt:
-   modified on: 28 Aug 2017 09:58:31
+   modified on: 30 Aug 2017 16:56:32
    size of file: 1988897
 ./build/prepare_data/sconscript_create_data.log:
-   modified on: 28 Aug 2017 09:58:31
+   modified on: 30 Aug 2017 16:56:32
    size of file: 99
 ./release/sconstruct.log:
-   modified on: 30 Aug 2017 16:06:06
-   size of file: 692
+   modified on: 31 Aug 2017 08:42:35
+   size of file: 250
 ./release/state_of_repo.log:
-   modified on: 30 Aug 2017 16:06:06
-   size of file: 2737
+   modified on: 31 Aug 2017 08:42:34
+   size of file: 2744
 ./release/descriptive/plot.eps:
-   modified on: 30 Aug 2017 16:06:06
+   modified on: 31 Aug 2017 08:17:47
    size of file: 15385
 ./release/descriptive/sconscript_descriptive.log:
-   modified on: 30 Aug 2017 16:06:06
+   modified on: 31 Aug 2017 08:17:47
    size of file: 99
 ./release/descriptive/table.txt:
-   modified on: 30 Aug 2017 16:06:06
+   modified on: 30 Aug 2017 16:56:33
    size of file: 39
 ./release/lg/data.txt:
    modified on: 28 Aug 2017 09:58:31

--- a/analysis/release/state_of_repo.log
+++ b/analysis/release/state_of_repo.log
@@ -8,18 +8,17 @@ as it can be edited after state_of_repo.log finishes running
 ===================================
 Last commit:
 
-commit 7dfbad4d62e1eab5d0b6a588f0cf321a86509d23
-Author: Quan Le <lequan@stanford.edu>
-Date:   Mon Aug 28 10:20:14 2017 -0700
+commit 465b8d9f106e4753bbe020d28d944c38128b1324
+Author: chuanyu <yuchuan2016@gmail.com>
+Date:   Tue Aug 29 16:12:39 2017 -0700
 
-    rm accidental commit of local scripts
+    #63 add builder check
 
 
 Files changed since last commit:
 
-analysis/SConstruct
-analysis/config_global.yaml
-analysis/configuration_test.py
+analysis/release/descriptive/plot.eps
+analysis/release/descriptive/sconscript_descriptive.log
 analysis/release/sconstruct.log
 analysis/release/state_of_repo.log
 
@@ -29,31 +28,28 @@ analysis/release/state_of_repo.log
 
 ===================================
 ./config_global.yaml:
-   modified on: 29 Aug 2017 16:00:37
-   size of file: 259
+   modified on: 30 Aug 2017 13:28:40
+   size of file: 195
 ./config_user.yaml:
    modified on: 25 Aug 2017 11:06:38
    size of file: 70
-./configuration_test.py:
-   modified on: 29 Aug 2017 15:33:37
-   size of file: 1759
 ./SConstruct:
-   modified on: 29 Aug 2017 16:00:39
-   size of file: 2416
+   modified on: 30 Aug 2017 16:02:14
+   size of file: 2250
 ./sconstruct.log:
-   modified on: 29 Aug 2017 16:04:05
+   modified on: 30 Aug 2017 16:06:12
    size of file: 199
 ./state_of_repo.log:
-   modified on: 29 Aug 2017 16:04:06
-   size of file: 575
+   modified on: 30 Aug 2017 16:06:12
+   size of file: 576
 ./build/descriptive/plot.eps:
-   modified on: 28 Aug 2017 16:48:11
+   modified on: 30 Aug 2017 16:06:06
    size of file: 15385
 ./build/descriptive/sconscript_descriptive.log:
-   modified on: 28 Aug 2017 16:48:11
+   modified on: 30 Aug 2017 16:06:06
    size of file: 99
 ./build/descriptive/table.txt:
-   modified on: 28 Aug 2017 16:48:11
+   modified on: 30 Aug 2017 16:06:06
    size of file: 39
 ./build/prepare_data/data.txt:
    modified on: 28 Aug 2017 09:58:31
@@ -62,19 +58,19 @@ analysis/release/state_of_repo.log
    modified on: 28 Aug 2017 09:58:31
    size of file: 99
 ./release/sconstruct.log:
-   modified on: 29 Aug 2017 16:00:43
-   size of file: 250
+   modified on: 30 Aug 2017 16:06:06
+   size of file: 692
 ./release/state_of_repo.log:
-   modified on: 29 Aug 2017 16:00:43
-   size of file: 2820
+   modified on: 30 Aug 2017 16:06:06
+   size of file: 2737
 ./release/descriptive/plot.eps:
-   modified on: 29 Aug 2017 13:34:54
+   modified on: 30 Aug 2017 16:06:06
    size of file: 15385
 ./release/descriptive/sconscript_descriptive.log:
-   modified on: 29 Aug 2017 13:34:54
+   modified on: 30 Aug 2017 16:06:06
    size of file: 99
 ./release/descriptive/table.txt:
-   modified on: 28 Aug 2017 16:48:11
+   modified on: 30 Aug 2017 16:06:06
    size of file: 39
 ./release/lg/data.txt:
    modified on: 28 Aug 2017 09:58:31

--- a/analysis/release/state_of_repo.log
+++ b/analysis/release/state_of_repo.log
@@ -8,30 +8,18 @@ as it can be edited after state_of_repo.log finishes running
 ===================================
 Last commit:
 
-commit 7529e71e04591eb9fd0a5683e112ff1b0cd6d224
-Author: chuanyu <yuchuan2016@gmail.com>
-Date:   Sun Aug 27 17:17:02 2017 -0700
+commit 7dfbad4d62e1eab5d0b6a588f0cf321a86509d23
+Author: Quan Le <lequan@stanford.edu>
+Date:   Mon Aug 28 10:20:14 2017 -0700
 
-    Pull Request for #64: Port example scripts to multiple languages (#76)
-    
-    * #64 add examples for python stata matlab R, mute everything except python
-    
-    * #64 add example of latex
-    
-    * #64 modify dependencies
-    
-    * #64 turn on git-lfs
-    
-    * #64 response to PR
-    
-    * #64 update readme and modify sample code
+    rm accidental commit of local scripts
 
 
 Files changed since last commit:
 
-analysis/release/descriptive/plot.eps
-analysis/release/descriptive/sconscript_descriptive.log
-analysis/release/descriptive/table.txt
+analysis/SConstruct
+analysis/config_global.yaml
+analysis/configuration_test.py
 analysis/release/sconstruct.log
 analysis/release/state_of_repo.log
 
@@ -41,55 +29,55 @@ analysis/release/state_of_repo.log
 
 ===================================
 ./config_global.yaml:
-   modified on: 28 Aug 2017 09:19:50
-   size of file: 361
+   modified on: 29 Aug 2017 16:00:37
+   size of file: 259
 ./config_user.yaml:
    modified on: 25 Aug 2017 11:06:38
    size of file: 70
 ./configuration_test.py:
-   modified on: 28 Aug 2017 09:19:50
-   size of file: 2286
+   modified on: 29 Aug 2017 15:33:37
+   size of file: 1759
 ./SConstruct:
-   modified on: 28 Aug 2017 09:19:50
-   size of file: 2226
+   modified on: 29 Aug 2017 16:00:39
+   size of file: 2416
 ./sconstruct.log:
-   modified on: 28 Aug 2017 09:22:05
+   modified on: 29 Aug 2017 16:04:05
    size of file: 199
 ./state_of_repo.log:
-   modified on: 28 Aug 2017 09:22:05
-   size of file: 933
+   modified on: 29 Aug 2017 16:04:06
+   size of file: 575
 ./build/descriptive/plot.eps:
-   modified on: 28 Aug 2017 09:22:02
+   modified on: 28 Aug 2017 16:48:11
    size of file: 15385
 ./build/descriptive/sconscript_descriptive.log:
-   modified on: 28 Aug 2017 09:22:02
+   modified on: 28 Aug 2017 16:48:11
    size of file: 99
 ./build/descriptive/table.txt:
-   modified on: 28 Aug 2017 09:22:01
+   modified on: 28 Aug 2017 16:48:11
    size of file: 39
 ./build/prepare_data/data.txt:
-   modified on: 28 Aug 2017 09:21:59
+   modified on: 28 Aug 2017 09:58:31
    size of file: 1988897
 ./build/prepare_data/sconscript_create_data.log:
-   modified on: 28 Aug 2017 09:21:59
+   modified on: 28 Aug 2017 09:58:31
    size of file: 99
 ./release/sconstruct.log:
-   modified on: 28 Aug 2017 09:22:02
-   size of file: 484
+   modified on: 29 Aug 2017 16:00:43
+   size of file: 250
 ./release/state_of_repo.log:
-   modified on: 28 Aug 2017 09:22:02
-   size of file: 3111
+   modified on: 29 Aug 2017 16:00:43
+   size of file: 2820
 ./release/descriptive/plot.eps:
-   modified on: 28 Aug 2017 09:22:02
+   modified on: 29 Aug 2017 13:34:54
    size of file: 15385
 ./release/descriptive/sconscript_descriptive.log:
-   modified on: 28 Aug 2017 09:22:02
+   modified on: 29 Aug 2017 13:34:54
    size of file: 99
 ./release/descriptive/table.txt:
-   modified on: 28 Aug 2017 09:22:01
+   modified on: 28 Aug 2017 16:48:11
    size of file: 39
 ./release/lg/data.txt:
-   modified on: 24 Aug 2017 14:08:59
+   modified on: 28 Aug 2017 09:58:31
    size of file: 1988897
 ./source/descriptive/descriptive.py:
    modified on: 28 Aug 2017 09:19:50
@@ -98,7 +86,7 @@ analysis/release/state_of_repo.log
    modified on: 28 Aug 2017 09:19:50
    size of file: 468
 ./source/prepare_data/create_data.do:
-   modified on: 28 Aug 2017 09:16:17
+   modified on: 28 Aug 2017 09:58:27
    size of file: 262
 ./source/prepare_data/create_data.m:
    modified on: 28 Aug 2017 09:19:50
@@ -110,5 +98,5 @@ analysis/release/state_of_repo.log
    modified on: 28 Aug 2017 09:19:50
    size of file: 247
 ./source/prepare_data/SConscript:
-   modified on: 28 Aug 2017 09:19:50
+   modified on: 28 Aug 2017 09:58:27
    size of file: 802

--- a/config/config_python.py
+++ b/config/config_python.py
@@ -1,0 +1,34 @@
+import pip
+import pkg_resources
+
+def main():
+    # Install gslab_tools if it's not installed yet or it has the wrong version
+    if not check_gslab_tools('4.1.0'):
+        pip.main(['install', 'git+http://git@github.com/gslab-econ/gslab_python.git@4.1.0'])
+
+    # Install required packages using pip
+    packages = {'pyyaml': True}
+    installed_packages = [pkg.key for pkg in pip.get_installed_distributions()]
+    for pkg in packages.keys():
+        if pkg not in installed_packages or packages[pkg]:
+            pip.main(['install', '--upgrade', pkg])
+
+def check_gslab_tools(gslab_python_version):
+    try:
+        installed = pkg_resources.get_distribution('gslab_tools').version.split('.')
+    except pkg_resources.DistributionNotFound:
+        return False
+
+    installed = int(installed[0]) * 10000 + \
+                int(installed[1]) * 100 + \
+                int(installed[2])
+    required = str(gslab_python_version).split('.')
+    required = int(required[0]) * 10000 + \
+               int(required[1]) * 100 + \
+               int(required[2])
+    if installed < required:
+        return False
+    else:
+        return True
+
+main()

--- a/config/config_python.py
+++ b/config/config_python.py
@@ -5,8 +5,7 @@ packages = ['pyyaml']
 
 def main(packages, upgrade = False):
     # Install gslab_tools if it's not installed yet or it has the wrong version
-    if not check_gslab_tools('4.1.0'):
-        pip.main(['install', 'git+http://git@github.com/gslab-econ/gslab_python.git@4.1.0'])
+    pip.main(['install', 'git+http://git@github.com/gslab-econ/gslab_python.git@4.1.0'])
 
     # Install required packages using pip
     installed_packages = [pkg.key for pkg in pip.get_installed_distributions()]
@@ -15,24 +14,6 @@ def main(packages, upgrade = False):
             pip.main(['install', '--upgrade', pkg])
         elif pkg not in installed_packages:
             pip.main(['install', pkg])
-
-def check_gslab_tools(gslab_python_version):
-    try:
-        installed = pkg_resources.get_distribution('gslab_tools').version.split('.')
-    except pkg_resources.DistributionNotFound:
-        return False
-
-    installed = int(installed[0]) * 10000 + \
-                int(installed[1]) * 100 + \
-                int(installed[2])
-    required = str(gslab_python_version).split('.')
-    required = int(required[0]) * 10000 + \
-               int(required[1]) * 100 + \
-               int(required[2])
-    if installed < required:
-        return False
-    else:
-        return True
 
 # upgrade = TRUE will update all packages to the most current version
 # upgrade = FALSE will skip packages that are already installed

--- a/config/config_python.py
+++ b/config/config_python.py
@@ -1,13 +1,16 @@
 import pip
 import pkg_resources
+# The collection of required packages.
+# Packages with value True will be updated if it's already installed.
+# Packages with value False will be skipped if it's already installed.
+packages = {'pyyaml': True}
 
-def main():
+def main(packages):
     # Install gslab_tools if it's not installed yet or it has the wrong version
     if not check_gslab_tools('4.1.0'):
         pip.main(['install', 'git+http://git@github.com/gslab-econ/gslab_python.git@4.1.0'])
 
     # Install required packages using pip
-    packages = {'pyyaml': True}
     installed_packages = [pkg.key for pkg in pip.get_installed_distributions()]
     for pkg in packages.keys():
         if pkg not in installed_packages or packages[pkg]:
@@ -31,4 +34,4 @@ def check_gslab_tools(gslab_python_version):
     else:
         return True
 
-main()
+main(packages)

--- a/config/config_python.py
+++ b/config/config_python.py
@@ -1,20 +1,20 @@
 import pip
 import pkg_resources
-# The collection of required packages.
-# Packages with value True will be updated if it's already installed.
-# Packages with value False will be skipped if it's already installed.
-packages = {'pyyaml': True}
+# The collection of required packages
+packages = ['pyyaml']
 
-def main(packages):
+def main(packages, upgrade = False):
     # Install gslab_tools if it's not installed yet or it has the wrong version
     if not check_gslab_tools('4.1.0'):
         pip.main(['install', 'git+http://git@github.com/gslab-econ/gslab_python.git@4.1.0'])
 
     # Install required packages using pip
     installed_packages = [pkg.key for pkg in pip.get_installed_distributions()]
-    for pkg in packages.keys():
-        if pkg not in installed_packages or packages[pkg]:
+    for pkg in packages:
+        if upgrade:
             pip.main(['install', '--upgrade', pkg])
+        elif pkg not in installed_packages:
+            pip.main(['install', pkg])
 
 def check_gslab_tools(gslab_python_version):
     try:
@@ -34,4 +34,6 @@ def check_gslab_tools(gslab_python_version):
     else:
         return True
 
-main(packages)
+# upgrade = TRUE will update all packages to the most current version
+# upgrade = FALSE will skip packages that are already installed
+main(packages, upgrade = False)

--- a/config/config_python.py
+++ b/config/config_python.py
@@ -5,7 +5,7 @@ packages = ['pyyaml']
 
 def main(packages, upgrade = False):
     # Install gslab_tools if it's not installed yet or it has the wrong version
-    pip.main(['install', 'git+http://git@github.com/gslab-econ/gslab_python.git@4.1.0'])
+    pip.main(['install', '--upgrade', 'git+http://git@github.com/gslab-econ/gslab_python.git@v4.1.0'])
 
     # Install required packages using pip
     installed_packages = [pkg.key for pkg in pip.get_installed_distributions()]

--- a/config/config_r.r
+++ b/config/config_r.r
@@ -1,0 +1,28 @@
+Main <- function(){
+    CRAN_packages   <- c("yaml", "ggplot2")
+    GitHub_packages <- NULL
+    # GitHub packages should be the full path to the relevant repo
+    if (!is.null(GitHub_packages)) {
+        CRAN_packages <- c(CRAN_packages, "devtools")
+    }
+
+    # Install packages from CRAN
+    if (!is.null(CRAN_packages)) {
+        lapply(CRAN_packages, install_CRAN, repo = "http://cran.cnr.Berkeley.edu/",
+                              dependency = TRUE, quiet = TRUE)
+    }
+
+    # Install packages from GitHub
+    if (!is.null(GitHub_packages)) {
+        library(devtools)
+        lapply(GitHub_packages, function(pkg) install_github(pkg))
+    }
+}
+
+install_CRAN <- function(pkg, repo, dependency, quiet){
+    if (system.file(package = pkg) == "") {
+        install.packages(pkg, repos = repo, dependencies = dependency, quiet = quiet)
+    }
+}
+
+Main()

--- a/config/config_r.r
+++ b/config/config_r.r
@@ -3,7 +3,8 @@ CRAN_packages   <- c("yaml")
 # Required packages installed from Github. Should be the full path to the relevant repo.
 GitHub_packages <- NULL
 
-main <- function(CRAN_packages = NULL, GitHub_packages = NULL) {
+main <- function(CRAN_packages = NULL, GitHub_packages = NULL,
+                 CRAN_dependency = TRUE, CRAN_quiet = TRUE, upgrade = FALSE) {
     # If there are packages installed from Github, first make sure "devtools" is installed 
     if (!is.null(GitHub_packages)) {
         CRAN_packages <- c(CRAN_packages, "devtools")
@@ -12,7 +13,7 @@ main <- function(CRAN_packages = NULL, GitHub_packages = NULL) {
     # Install packages from CRAN
     if (!is.null(CRAN_packages)) {
         lapply(CRAN_packages, install_CRAN, repo = "http://cran.cnr.Berkeley.edu/",
-                              dependency = TRUE, quiet = TRUE)
+               dependency = CRAN_dependency, quiet = CRAN_quiet, upgrade)
     }
 
     # Install packages from GitHub
@@ -22,10 +23,16 @@ main <- function(CRAN_packages = NULL, GitHub_packages = NULL) {
     }
 }
 
-install_CRAN <- function(pkg, repo, dependency, quiet){
-    if (system.file(package = pkg) == "") {
+install_CRAN <- function(pkg, repo, dependency, quiet, upgrade = FALSE) {
+    if (upgrade) {
         install.packages(pkg, repos = repo, dependencies = dependency, quiet = quiet)
+    } else {
+        if (system.file(package = pkg) == "") {
+            install.packages(pkg, repos = repo, dependencies = dependency, quiet = quiet)
+        }
     }
 }
 
-main(CRAN_packages, GitHub_packages)
+# upgrade = TRUE will update all packages to the most current version
+# upgrade = FALSE will skip packages that are already installed
+main(CRAN_packages, GitHub_packages, upgrade = FALSE)

--- a/config/config_r.r
+++ b/config/config_r.r
@@ -13,7 +13,8 @@ main <- function(CRAN_packages = NULL, GitHub_packages = NULL,
 
     # Install packages from CRAN
     if (!is.null(CRAN_packages)) {
-        lapply(CRAN_packages, install_CRAN, CRAN_repo, dependency, quiet, upgrade)
+        lapply(CRAN_packages, install_CRAN, repo = CRAN_repo, dependency = dependency,
+               quiet = quiet, upgrade = upgrade)
     }
 
     # Install packages from GitHub

--- a/config/config_r.r
+++ b/config/config_r.r
@@ -4,7 +4,8 @@ CRAN_packages   <- c("yaml")
 GitHub_packages <- NULL
 
 main <- function(CRAN_packages = NULL, GitHub_packages = NULL,
-                 CRAN_dependency = TRUE, CRAN_quiet = TRUE, upgrade = FALSE) {
+                 CRAN_repo = "http://cran.cnr.Berkeley.edu/",
+                 dependency = TRUE, quiet = TRUE, upgrade = FALSE) {
     # If there are packages installed from Github, first make sure "devtools" is installed 
     if (!is.null(GitHub_packages)) {
         CRAN_packages <- c(CRAN_packages, "devtools")
@@ -12,8 +13,7 @@ main <- function(CRAN_packages = NULL, GitHub_packages = NULL,
 
     # Install packages from CRAN
     if (!is.null(CRAN_packages)) {
-        lapply(CRAN_packages, install_CRAN, repo = "http://cran.cnr.Berkeley.edu/",
-               dependency = CRAN_dependency, quiet = CRAN_quiet, upgrade)
+        lapply(CRAN_packages, install_CRAN, CRAN_repo, dependency, quiet, upgrade)
     }
 
     # Install packages from GitHub

--- a/config/config_r.r
+++ b/config/config_r.r
@@ -1,7 +1,10 @@
-Main <- function(){
-    CRAN_packages   <- c("yaml", "ggplot2")
-    GitHub_packages <- NULL
-    # GitHub packages should be the full path to the relevant repo
+# Required packages installed from CRAN.
+CRAN_packages   <- c("yaml")
+# Required packages installed from Github. Should be the full path to the relevant repo.
+GitHub_packages <- NULL
+
+main <- function(CRAN_packages = NULL, GitHub_packages = NULL) {
+    # If there are packages installed from Github, first make sure "devtools" is installed 
     if (!is.null(GitHub_packages)) {
         CRAN_packages <- c(CRAN_packages, "devtools")
     }
@@ -25,4 +28,4 @@ install_CRAN <- function(pkg, repo, dependency, quiet){
     }
 }
 
-Main()
+main(CRAN_packages, GitHub_packages)

--- a/config/config_stata.do
+++ b/config/config_stata.do
@@ -1,0 +1,26 @@
+clear all
+set more off
+
+program main
+    * Install packages using ssc
+    local ssc_packages ""
+
+    if !missing("`ssc_packages'") {
+        foreach pkg in "`ssc_packages'" {
+            dis "Installing `pkg'"
+            quietly ssc install `pkg', replace
+        }
+    }
+
+    * Install packages using net
+    quietly net from "https://raw.githubusercontent.com/gslab-econ/stata-misc/master/"
+    quietly cap ado uninstall yaml
+    quietly net install yaml
+    quietly net from "https://raw.githubusercontent.com/gslab-econ/gslab_stata/master/gslab_misc/ado"
+    quietly cap net uninstall matrix_to_txt
+    quietly net install matrix_to_txt
+    quietly cap net uninstall preliminaries
+    quietly net install preliminaries
+end
+
+main

--- a/config/configuration.py
+++ b/config/configuration.py
@@ -1,48 +1,38 @@
 #!/usr/bin/python
 import sys
-import os
-import re
-import subprocess
 import warnings
-from shutil import copyfile
 from gslab_scons import _exception_classes
 from gslab_scons import misc
+from gslab_scons import configuration_tests as config
 
-def configuration_test(ARGUMENTS, gslab_python_version):
+def configuration(ARGUMENTS, config_user_yaml = 'config_user.yaml'):
     # Determines whether to print traceback messages
-    debug = ARGUMENTS.get('debug', False) 
+    debug = ARGUMENTS.get('debug', False)
     if not debug:
         # Hide traceback for configuration test only
         # http://stackoverflow.com/questions/27674602/hide-traceback-unless-a-debug-flag-is-set
-        sys.tracebacklimit = 0 
+        sys.tracebacklimit = 0
 
-    # Checks initial prerequisites
-    try:
-        from gslab_scons import configuration_tests as config
-    except ImportError:
-        message = 'Your gslab_tools Python modules installation is outdated'
-        raise Exception(message)
-
-    config.check_python(gslab_python_version = gslab_python_version, 
-                        packages = ['yaml', 'gslab_scons', 'gslab_fill'])
-
+    # Checks git-lfs and lyx
     config.check_lfs()
+    config.check_lyx()
+
     # Loads arguments and configurations
     mode = ARGUMENTS.get('mode', 'develop') # Gets mode; defaults to 'develop'
+    vers = ARGUMENTS.get('version', '')
 
     # Checks mode/version
     if not (mode in ['develop', 'cache']):
         message = 'Error: %s is not a defined mode' % mode
         raise _exception_classes.PrerequisiteError(message)
 
-    stata_executable = misc.load_yaml_value('config_user.yaml', 'stata_executable')
     # Get return list
     if mode == 'cache':
-        cache_dir   = misc.load_yaml_value('config_user.yaml', 'cache_directory')
+        cache_dir   = misc.load_yaml_value(config_user_yaml, 'cache_directory')
         cache_dir   = misc.check_and_expand_path(cache_dir)
-        return_list = [mode, stata_executable, cache_dir]
+        return_list = [mode, vers, cache_dir]
     else:
-        return_list = [mode, stata_executable, None]
+        return_list = [mode, vers, None]
 
     # Restore default tracebacklimit and return values
     sys.tracebacklimit = 1000

--- a/config/configuration.py
+++ b/config/configuration.py
@@ -5,7 +5,8 @@ from gslab_scons import _exception_classes
 from gslab_scons import misc
 from gslab_scons import configuration_tests as config
 
-def configuration(ARGUMENTS, config_user_yaml = 'config_user.yaml'):
+def configuration(ARGUMENTS, paper = False, config_user_yaml = 'config_user.yaml',
+                  config_global_yaml = 'config_global.yaml'):
     # Determines whether to print traceback messages
     debug = ARGUMENTS.get('debug', False)
     if not debug:
@@ -13,9 +14,19 @@ def configuration(ARGUMENTS, config_user_yaml = 'config_user.yaml'):
         # http://stackoverflow.com/questions/27674602/hide-traceback-unless-a-debug-flag-is-set
         sys.tracebacklimit = 0
 
-    # Checks git-lfs and lyx
-    config.check_lfs()
-    config.check_lyx()
+    # Checks git-lfs
+    prereq_gitlfs = misc.load_yaml_value(config_global_yaml, 'prereq_git-lfs')
+    if prereq_gitlfs:
+        config.check_lfs()
+
+    # Check lyx or latex
+    if paper:
+        prereq_lyx   = misc.load_yaml_value(config_global_yaml, 'prereq_Lyx')
+        prereq_latex = misc.load_yaml_value(config_global_yaml, 'prereq_Latex')
+        if prereq_lyx:
+            config.check_lyx()
+        if prereq_latex:
+            pass
 
     # Loads arguments and configurations
     mode = ARGUMENTS.get('mode', 'develop') # Gets mode; defaults to 'develop'

--- a/paper_slides/SConstruct
+++ b/paper_slides/SConstruct
@@ -1,27 +1,29 @@
 # Preliminaries
 import os
 import sys
+import atexit
+import yaml
+sys.path.append('../config')
 sys.dont_write_bytecode = True # Don't write .pyc files
 
-# Test for proper prerequisites and setup
-from configuration_test import configuration_test
-[mode, cache_dir] = configuration_test(ARGUMENTS, gslab_python_version = '4.1.0')
+# Setup
+from configuration import configuration
+[mode, vers, cache_dir] = configuration(ARGUMENTS, paper = True)
 import gslab_scons as gs
-import gslab_scons.log as log
-import yaml
-import atexit
+from gslab_scons import log
+from gslab_scons import misc
 
-# Start log after getting mode and release version
-mode = ARGUMENTS.get('mode', 'develop') 
-vers = ARGUMENTS.get('version', '') 
+# Start log
 log.start_log(mode, vers)
 
 # Define the SCons environment
 env = Environment(ENV = {'PATH': os.environ['PATH']}, 
                   IMPLICIT_COMMAND_DEPENDENCIES = 0,
-                  BUILDERS = {'BuildLyx':   Builder(action = gs.build_lyx),
-                              'BuildLatex': Builder(action = gs.build_latex),
-                              'Tablefill':  Builder(action = gs.build_tables)})
+                  BUILDERS = {
+                              'BuildLyx':   Builder(action = gs.build_lyx),
+                              # 'BuildLatex': Builder(action = gs.build_latex),
+                              'Tablefill':  Builder(action = gs.build_tables),
+                              })
 
 # Only computes hash if time-stamp changed
 env.Decider('MD5-timestamp') 

--- a/paper_slides/config_global.yaml
+++ b/paper_slides/config_global.yaml
@@ -14,7 +14,7 @@ source:
   tables: source/tables
   talk: source/talk
 
-# Switch to 'Yes' if any of the following softwares are required
+# Switch to 'Yes' if it's required and 'No' if it's not.
 prereq_git-lfs: Yes
 prereq_Latex: No
 prereq_Lyx: Yes

--- a/paper_slides/release/sconstruct.log
+++ b/paper_slides/release/sconstruct.log
@@ -1,9 +1,9 @@
-*** New build: {2017-08-25 16:32:48} ***
+*** New build: {2017-08-31 09:01:29} ***
 scons: done reading SConscript files.
 scons: Building targets ...
 scons: `build' is up to date.
 scons: `release' is up to date.
 scons: done building targets.
-*** Build completed: {2017-08-25 16:32:49} ***
+*** Build completed: {2017-08-31 09:01:30} ***
  
  

--- a/paper_slides/release/state_of_repo.log
+++ b/paper_slides/release/state_of_repo.log
@@ -8,22 +8,24 @@ as it can be edited after state_of_repo.log finishes running
 ===================================
 Last commit:
 
-commit 5fafb61cb4248d84dd6a94b523b948768c8d2dda
+commit 5d85886f5a4b83fbe91cb9988373921cdbbba603
 Author: chuanyu <yuchuan2016@gmail.com>
-Date:   Thu Aug 24 17:02:41 2017 -0700
+Date:   Wed Aug 30 16:07:40 2017 -0700
 
-    #64 turn on git-lfs
+    #63 add autimatic config scripts
 
 
 Files changed since last commit:
 
 analysis/SConstruct
 analysis/config_global.yaml
-analysis/configuration_test.py
 analysis/release/sconstruct.log
 analysis/release/state_of_repo.log
+config/config_python.py
+config/config_r.r
+config/configuration.py
+paper_slides/SConstruct
 paper_slides/config_global.yaml
-paper_slides/configuration_test.py
 paper_slides/release/sconstruct.log
 paper_slides/release/state_of_repo.log
 
@@ -33,20 +35,20 @@ paper_slides/release/state_of_repo.log
 
 ===================================
 ./config_global.yaml:
-   modified on: 25 Aug 2017 16:32:20
-   size of file: 365
+   modified on: 31 Aug 2017 09:00:44
+   size of file: 357
 ./configuration_test.py:
-   modified on: 25 Aug 2017 16:32:33
+   modified on: 28 Aug 2017 09:19:50
    size of file: 2016
 ./SConstruct:
-   modified on: 25 Aug 2017 16:05:28
-   size of file: 1877
+   modified on: 31 Aug 2017 09:01:21
+   size of file: 1820
 ./sconstruct.log:
-   modified on: 25 Aug 2017 16:32:49
+   modified on: 31 Aug 2017 09:01:30
    size of file: 199
 ./state_of_repo.log:
-   modified on: 25 Aug 2017 16:32:49
-   size of file: 701
+   modified on: 31 Aug 2017 09:01:30
+   size of file: 738
 ./build/paper/ondeck.pdf:
    modified on: 24 Aug 2017 16:51:29
    size of file: 18193
@@ -93,7 +95,7 @@ paper_slides/release/state_of_repo.log
    modified on: 24 Aug 2017 16:52:19
    size of file: 29971
 ./input/plot.eps:
-   modified on: 25 Aug 2017 16:05:28
+   modified on: 28 Aug 2017 09:19:50
    size of file: 15385
 ./input/provenance.txt:
    modified on: 23 Aug 2017 12:00:48
@@ -102,31 +104,31 @@ paper_slides/release/state_of_repo.log
    modified on: 24 Aug 2017 15:33:21
    size of file: 39
 ./release/sconstruct.log:
-   modified on: 25 Aug 2017 16:32:38
+   modified on: 31 Aug 2017 08:59:45
    size of file: 250
 ./release/state_of_repo.log:
-   modified on: 25 Aug 2017 16:32:38
-   size of file: 4478
+   modified on: 31 Aug 2017 08:59:45
+   size of file: 4589
 ./release/paper/ondeck.pdf:
-   modified on: 25 Aug 2017 16:05:28
+   modified on: 28 Aug 2017 09:19:50
    size of file: 18193
 ./release/paper/online_appendix.pdf:
-   modified on: 25 Aug 2017 16:05:28
+   modified on: 28 Aug 2017 09:19:50
    size of file: 45354
 ./release/paper/paper.pdf:
-   modified on: 25 Aug 2017 16:05:28
+   modified on: 28 Aug 2017 09:19:50
    size of file: 58961
 ./release/paper/sconscript.log:
-   modified on: 25 Aug 2017 16:05:28
+   modified on: 28 Aug 2017 09:19:50
    size of file: 6473
 ./release/paper/text.pdf:
-   modified on: 25 Aug 2017 16:05:28
+   modified on: 28 Aug 2017 09:19:50
    size of file: 18193
 ./release/talk/sconscript.log:
-   modified on: 25 Aug 2017 16:05:28
+   modified on: 28 Aug 2017 09:19:50
    size of file: 589
 ./release/talk/slides.pdf:
-   modified on: 25 Aug 2017 16:05:28
+   modified on: 28 Aug 2017 09:19:50
    size of file: 29971
 ./source/figures/figure.lyx:
    modified on: 23 Aug 2017 12:00:56
@@ -141,13 +143,13 @@ paper_slides/release/state_of_repo.log
    modified on: 23 Aug 2017 12:00:56
    size of file: 5236
 ./source/paper/SConscript:
-   modified on: 25 Aug 2017 16:05:28
-   size of file: 676
+   modified on: 28 Aug 2017 09:19:50
+   size of file: 677
 ./source/paper/text.lyx:
    modified on: 23 Aug 2017 12:00:56
    size of file: 2522
 ./source/paper/text.tex:
-   modified on: 25 Aug 2017 16:05:28
+   modified on: 28 Aug 2017 09:19:50
    size of file: 1300
 ./source/tables/SConscript:
    modified on: 23 Aug 2017 12:00:56


### PR DESCRIPTION
@stanfordquan , can you take a look at this? I'm a little stuck on how to specify the required packages for each build. Previously if we add a new package requirement, we just add it in the argument of `check_xx` function in `configuration_test.py`. But now the check is after the definition of the builders. Also I'm not sure how to pass the packages arguments in a `dict` syntax.

My current solution is to store the required packages in `config_global.yaml` and add some "hard code" in `gslab_python`. Can you think of a better solution of this? I think this problem won't exist in a world with automatic dependencies installation.