### PR TITLE
Pull Request For #110: yaml.load(input) deprecated

### DIFF
--- a/analysis/release/descriptive/plot.eps
+++ b/analysis/release/descriptive/plot.eps
@@ -1,7 +1,7 @@
 %!PS-Adobe-3.0 EPSF-3.0
 %%Title: build/descriptive/plot.eps
-%%Creator: matplotlib version 2.1.1, http://matplotlib.org/
-%%CreationDate: Wed Feb 14 21:21:58 2018
+%%Creator: matplotlib version 2.2.3, http://matplotlib.org/
+%%CreationDate: Wed Jan 29 21:08:02 2020
 %%Orientation: portrait
 %%BoundingBox: 75 223 536 568
 %%EndComments

--- a/analysis/release/descriptive/sconscript_descriptive.log
+++ b/analysis/release/descriptive/sconscript_descriptive.log
@@ -1,2 +1,2 @@
-*** Builder log created: {2018-02-14 21:21:56}
-*** Builder log completed: {2018-02-14 21:21:58}
+*** Builder log created: {2020-01-29 21:07:57}
+*** Builder log completed: {2020-01-29 21:08:02}

--- a/analysis/release/sconstruct.log
+++ b/analysis/release/sconstruct.log
@@ -1,9 +1,20 @@
-*** New build: {2018-03-02 10:12:12} ***
+*** New build: {2020-01-29 21:07:56} ***
 scons: done reading SConscript files.
 scons: Building targets ...
 build_python(["build/prepare_data/data.txt"], ["source/prepare_data/create_data.py"])
-scons: `release' is up to date.
+build_python(["build/descriptive/plot.eps", "build/descriptive/table.txt"], ["source/descriptive/descriptive.py", "build/prepare_data/data.txt"])
+Install directory: "build/descriptive" as "release/descriptive"
+Install file: "build/prepare_data/data.txt" as "release/lg/data.txt"
 scons: done building targets.
-*** Build completed: {2018-03-02 10:12:12} ***
+*** Build completed: {2020-01-29 21:08:02} ***
  
  
+./release/descriptive/sconscript_descriptive.log
+*** Builder log created: {2020-01-29 21:07:57}
+*** Builder log completed: {2020-01-29 21:08:02}
+./build/descriptive/sconscript_descriptive.log
+*** Builder log created: {2020-01-29 21:07:57}
+*** Builder log completed: {2020-01-29 21:08:02}
+./build/prepare_data/sconscript_create_data.log
+*** Builder log created: {2020-01-29 21:07:56}
+*** Builder log completed: {2020-01-29 21:07:57}

--- a/analysis/release/state_of_repo.log
+++ b/analysis/release/state_of_repo.log
@@ -8,98 +8,96 @@ as it can be edited after state_of_repo.log finishes running
 ===================================
 Last commit:
 
-commit 2c30ad8bb276736db4d645000f715810767e2a33
-Author: Adam Rosenberg <arosenbe@stanford.edu>
-Date:   Thu Feb 15 10:43:55 2018 -0800
+commit b02e51d5a0b9c1090cda24367c2d68c7f4fb131b
+Author: David Ritzwoller <David.Ritzwoller@gmail.com>
+Date:   Wed Jan 29 21:06:58 2020 -0800
 
-    #96 drop _ before anything builder
+    #110 add Loader
 
 
 Files changed since last commit:
 
 
-README.md
+analysis/release/descriptive/plot.eps
+analysis/release/descriptive/sconscript_descriptive.log
 
 ===================================
 
  *** FILE STATUS ***
 
 ===================================
-./config_global.yaml:
-   modified on: 02 Mar 2018 10:03:34
-   size of file: 1264
 ./config_user.yaml:
-   modified on: 14 Feb 2018 21:21:10
-   size of file: 619
+   modified on: 29 Jan 2020 21:07:56
+   size of file: 646
 ./run.py:
-   modified on: 12 Feb 2018 13:11:33
-   size of file: 458
-./SConstruct:
-   modified on: 02 Mar 2018 10:11:38
-   size of file: 1878
-./sconstruct.log:
-   modified on: 02 Mar 2018 10:12:12
-   size of file: 255
+   modified on: 23 Aug 2019 16:10:40
+   size of file: 449
 ./state_of_repo.log:
-   modified on: 02 Mar 2018 10:12:12
-   size of file: 453
-./build/descriptive/plot.eps:
-   modified on: 02 Mar 2018 09:46:49
-   size of file: 12351
-./build/descriptive/sconscript_descriptive.log:
-   modified on: 02 Mar 2018 09:46:49
-   size of file: 96
-./build/descriptive/table.txt:
-   modified on: 02 Mar 2018 09:46:49
-   size of file: 39
-./build/prepare_data/data.txt:
-   modified on: 02 Mar 2018 10:12:12
-   size of file: 1988897
-./build/prepare_data/sconscript_create_data.log:
-   modified on: 02 Mar 2018 10:12:12
-   size of file: 96
-./release/create_data.log:
-   modified on: 02 Mar 2018 10:02:13
-   size of file: 1498
-./release/sconstruct.log:
-   modified on: 02 Mar 2018 10:10:51
-   size of file: 841
-./release/state_of_repo.log:
-   modified on: 02 Mar 2018 10:10:51
-   size of file: 3673
-./release/descriptive/plot.eps:
-   modified on: 02 Mar 2018 10:10:51
-   size of file: 12351
-./release/descriptive/sconscript_descriptive.log:
-   modified on: 02 Mar 2018 10:10:51
-   size of file: 96
-./release/descriptive/table.txt:
-   modified on: 02 Mar 2018 09:46:49
-   size of file: 39
-./release/lg/data.txt:
-   modified on: 02 Mar 2018 09:46:45
-   size of file: 1988897
-./source/descriptive/descriptive.py:
-   modified on: 12 Feb 2018 10:17:21
-   size of file: 548
-./source/descriptive/SConscript:
-   modified on: 12 Feb 2018 10:16:38
-   size of file: 501
-./source/prepare_data/create_data.do:
-   modified on: 09 Jan 2018 08:11:40
-   size of file: 262
+   modified on: 29 Jan 2020 21:08:02
+   size of file: 525
+./SConstruct:
+   modified on: 23 Aug 2019 16:10:40
+   size of file: 1878
+./config_global.yaml:
+   modified on: 23 Aug 2019 16:10:40
+   size of file: 1264
+./sconstruct.log:
+   modified on: 29 Jan 2020 21:08:02
+   size of file: 502
 ./source/prepare_data/create_data.m:
-   modified on: 12 Feb 2018 10:17:58
+   modified on: 23 Aug 2019 16:10:40
    size of file: 202
+./source/prepare_data/create_data.sh:
+   modified on: 23 Aug 2019 16:10:40
+   size of file: 81
+./source/prepare_data/create_data.do:
+   modified on: 23 Aug 2019 16:10:40
+   size of file: 262
+./source/prepare_data/SConscript:
+   modified on: 23 Aug 2019 16:10:40
+   size of file: 1126
 ./source/prepare_data/create_data.py:
-   modified on: 14 Feb 2018 21:21:44
+   modified on: 23 Aug 2019 16:10:40
    size of file: 260
 ./source/prepare_data/create_data.r:
-   modified on: 12 Feb 2018 10:19:10
+   modified on: 23 Aug 2019 16:10:40
    size of file: 249
-./source/prepare_data/create_data.sh:
-   modified on: 09 Jan 2018 08:11:40
-   size of file: 81
-./source/prepare_data/SConscript:
-   modified on: 02 Mar 2018 10:12:04
-   size of file: 1126
+./source/descriptive/descriptive.py:
+   modified on: 23 Aug 2019 16:10:40
+   size of file: 548
+./source/descriptive/SConscript:
+   modified on: 23 Aug 2019 16:10:40
+   size of file: 501
+./release/state_of_repo.log:
+   modified on: 23 Aug 2019 16:10:40
+   size of file: 2874
+./release/sconstruct.log:
+   modified on: 23 Aug 2019 16:10:40
+   size of file: 306
+./release/descriptive/sconscript_descriptive.log:
+   modified on: 29 Jan 2020 21:08:02
+   size of file: 96
+./release/descriptive/plot.eps:
+   modified on: 29 Jan 2020 21:08:02
+   size of file: 12351
+./release/descriptive/table.txt:
+   modified on: 29 Jan 2020 21:08:01
+   size of file: 39
+./release/lg/data.txt:
+   modified on: 29 Jan 2020 21:07:57
+   size of file: 1988897
+./build/prepare_data/sconscript_create_data.log:
+   modified on: 29 Jan 2020 21:07:57
+   size of file: 96
+./build/prepare_data/data.txt:
+   modified on: 29 Jan 2020 21:07:57
+   size of file: 1988897
+./build/descriptive/sconscript_descriptive.log:
+   modified on: 29 Jan 2020 21:08:02
+   size of file: 96
+./build/descriptive/plot.eps:
+   modified on: 29 Jan 2020 21:08:02
+   size of file: 12351
+./build/descriptive/table.txt:
+   modified on: 29 Jan 2020 21:08:01
+   size of file: 39

--- a/config/configuration.py
+++ b/config/configuration.py
@@ -39,7 +39,7 @@ def configuration(ARGUMENTS, paper = False, config_user_yaml = 'config_user.yaml
     # Loads config yaml files
     CONFIG = {'user': config_user_yaml, 'global': config_global_yaml}
     for key, val in CONFIG.items():
-        CONFIG[key] = yaml.load(open(val, 'rU'))
+        CONFIG[key] = yaml.load(open(val, 'rU'), Loader = yaml.FullLoader)
         if not CONFIG[key]:
             del CONFIG[key]
 


### PR DESCRIPTION
@mengsongouyang Can you confirm the change I made here works well and makes sense. See [here](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation) for background. 

