### PR TITLE
Pull Request for Issue 117: YAML Loader update

### DIFF
--- a/config/configuration.py
+++ b/config/configuration.py
@@ -39,7 +39,7 @@ def configuration(ARGUMENTS, paper = False, config_user_yaml = 'config_user.yaml
     # Loads config yaml files
     CONFIG = {'user': config_user_yaml, 'global': config_global_yaml}
     for key, val in CONFIG.items():
-        CONFIG[key] = yaml.load(open(val, 'rU'), Loader = yaml.FullLoader)
+        CONFIG[key] = yaml.load(open(val, 'rU'), Loader = yaml.SafeLoader)
         if not CONFIG[key]:
             del CONFIG[key]
 


### PR DESCRIPTION
In this issue I changed the specification of which loader for `yaml` we use in order to make the template backwards compatible with older Macs.