### PR TITLE
Local Quotations

### DIFF
--- a/config/config_stata.do
+++ b/config/config_stata.do
@@ -7,7 +7,7 @@ program main
     * *** Add required packages from SSC to this list ***
 
     if !missing("`ssc_packages'") {
-        foreach pkg in "`ssc_packages'" {
+        foreach pkg in `ssc_packages' {
         * install using ssc, but avoid re-installing if already present
             capture which `pkg'
             if _rc == 111 {                 

--- a/config/config_stata.do
+++ b/config/config_stata.do
@@ -8,20 +8,35 @@ program main
 
     if !missing("`ssc_packages'") {
         foreach pkg in "`ssc_packages'" {
-            dis "Installing `pkg'"
-            quietly ssc install `pkg', replace
+        * install using ssc, but avoid re-installing if already present
+            capture which `pkg'
+            if _rc == 111 {                 
+               dis "Installing `pkg'"
+               quietly ssc install `pkg', replace
+               }
         }
     }
 
-    * Install packages using net
-    quietly net from "https://raw.githubusercontent.com/gslab-econ/stata-misc/master/"
-    quietly cap ado uninstall yaml
-    quietly net install yaml
+    * Install packages using net, but avoid re-installing if already present
+    capture which yaml
+       if _rc == 111 {
+        quietly net from "https://raw.githubusercontent.com/gslab-econ/stata-misc/master/"
+        quietly cap ado uninstall yaml
+        quietly net install yaml
+       }
+    * Install complicated packages : moremata (which cannot be tested for with which)
+    capture confirm file $adobase/plus/m/moremata.hlp
+        if _rc != 0 {
+        cap ado uninstall moremata
+        ssc install moremata
+        }
+     * Standard GSLAB stuff
     quietly net from "https://raw.githubusercontent.com/gslab-econ/gslab_stata/master/gslab_misc/ado"
-    quietly cap net uninstall matrix_to_txt
-    quietly net install matrix_to_txt
-    quietly cap net uninstall preliminaries
-    quietly net install preliminaries
+       quietly cap net uninstall matrix_to_txt
+       quietly net install matrix_to_txt
+       quietly cap net uninstall preliminaries
+       quietly net install preliminaries
+
 end
 
 main


### PR DESCRIPTION
The line **_foreach pkg in "`ssc_packages'" {_**
 
should instead read **_foreach pkg in `ssc_packages' {_** 
 
When the quotes around the local are included it reads as a single string in the foreach loop. The code does not break because of capture, but it will not install the individual packages.
